### PR TITLE
fix 404 page if 'admin' or 'admin/' was requested

### DIFF
--- a/Classes/Plugin.php
+++ b/Classes/Plugin.php
@@ -42,6 +42,9 @@ class Plugin extends \Phile\Plugin\AbstractPlugin implements \Phile\Gateway\Even
 				if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
 					$page = new Pages($this->settings);
 					// redirect missing pages to the home page
+					if (!isset($uri[1]) || $uri[1] === '') {
+						$uri[1] = $this->settings['nav'][0]['url'];
+					}
 					if (method_exists($page, $uri[1])) {
 						$page->{$uri[1]}();
 					} else {


### PR DESCRIPTION
I've just downloaded your plugin and hit 404 when went to `admin/` (even worse, I encountered exception when typed `admin` without slash). This fix fetches first page URL from `settings['nav']` list, so that it's opened by default. There was a comment _redirect missing pages to the home page_, but I don't think it works (it doesn't work for me).

Alternatively, there could be 'index' method in Pages (so here you'd have `if (!isset($uri[1]) || $uri[1] === '') $url[1] = 'index';`), which could default to some arbitrary page or first from nav, like here.
